### PR TITLE
Fix for issue when app is backgrounded on Android

### DIFF
--- a/src/android/CropPlugin.java
+++ b/src/android/CropPlugin.java
@@ -92,4 +92,31 @@ public class CropPlugin extends CordovaPlugin {
         cache.mkdirs();
         return cache.getAbsolutePath();
     }
+
+    public Bundle onSaveInstanceState() {
+        Bundle state = new Bundle();
+
+        if (this.inputUri != null) {
+            state.putString("inputUri", this.inputUri.toString());
+        }
+
+        if (this.outputUri != null) {
+            state.putString("outputUri", this.outputUri.toString());
+        }
+
+        return state;
+    }
+
+    public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+
+        if (state.containsKey("inputUri")) {
+            this.inputUri = Uri.parse(state.getString("inputUri"));
+        }
+
+        if (state.containsKey("outputUri")) {
+            this.inputUri = Uri.parse(state.getString("outputUri"));
+        }
+
+        this.callbackContext = callbackContext;
+    }
 }


### PR DESCRIPTION
Adding updates to fix a potential Null Pointer exception from happening on Android when an Activity is killed due to the device having low memory. The exception was happening due to the callbackContext being null.

This change means that the onResume callback function inside your JS code will now be populated for the pluginServiceName "CropPlugin"

http://cordova.apache.org/docs/en/dev/guide/platforms/android/index.html#lifecycle-guide
