### PR TITLE
New option "keepAspectRatio"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The resulting JPEG picture width. default: -1
 
 The resulting JPEG picture height. default: -1
 
+ * keepAspectRatio: Number
+
+Defines if cropping should keep the specified aspect ratio (1) or not (0). default: 1
+
 ## Ionic / Typescript Example Angular 2 Service
 
 <img src="screenshot-example.png" width="250" height="500">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Install
 
 ```
-$ cordova plugin add --save cordova-plugin-crop
+$ cordova plugin add --save https://github.com/rastafan/cordova-plugin-crop
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-crop",
-  "version": "0.4.0",
+  "version": "0.3.3",
   "description": "Crop an image in a Cordova app",
   "cordova": {
     "id": "cordova-plugin-crop",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="cordova-plugin-crop"
-  version="0.3.1">
+  version="0.3.2">
 
   <name>CropPlugin</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="cordova-plugin-crop"
-  version="0.3.2">
+  version="0.3.3">
 
   <name>CropPlugin</name>
 

--- a/src/android/CropPlugin.java
+++ b/src/android/CropPlugin.java
@@ -29,6 +29,7 @@ public class CropPlugin extends CordovaPlugin {
           JSONObject options = args.getJSONObject(1);
           int targetWidth = options.getInt("targetWidth");
           int targetHeight = options.getInt("targetHeight");
+          int keepAspectRatio = options.getInt("keepAspectRatio");
 
           this.inputUri = Uri.parse(imagePath);
           this.outputUri = Uri.fromFile(new File(getTempDirectoryPath() + "/" + System.currentTimeMillis()+ "-cropped.jpg"));
@@ -42,11 +43,18 @@ public class CropPlugin extends CordovaPlugin {
           Crop crop = Crop.of(this.inputUri, this.outputUri);
           if(targetHeight != -1 && targetWidth != -1) {
               crop.withMaxSize(targetWidth, targetHeight);
-              if(targetWidth == targetHeight) {
-                  crop.asSquare();
+              if(keepAspectRatio != 0) {
+                if(targetWidth == targetHeight) {
+                    crop.asSquare();
+                }else{
+                    crop.withAspect(targetWidth, targetHeight);
+                }
               }
+              
           } else {
-              crop.asSquare();
+              if(keepAspectRatio != 0){
+                crop.asSquare();
+              }
           }
           crop.start(cordova.getActivity());
           return true;

--- a/src/ios/CTCrop.m
+++ b/src/ios/CTCrop.m
@@ -7,6 +7,7 @@
 @property (assign) NSUInteger quality;
 @property (assign) NSUInteger targetWidth;
 @property (assign) NSUInteger targetHeight;
+@property (assign) BOOL keepAspectRatio;
 @end
 
 @implementation CTCrop
@@ -19,6 +20,7 @@
     self.quality = options[@"quality"] ? [options[@"quality"] intValue] : 100;
     self.targetWidth = options[@"targetWidth"] ? [options[@"targetWidth"] intValue] : -1;
     self.targetHeight = options[@"targetHeight"] ? [options[@"targetHeight"] intValue] : -1;
+    self.keepAspectRatio = options[@"keepAspectRatio"]  ? [options[@"keepAspectRatio"] intValue] : 1;
     NSString *filePrefix = @"file://";
     
     if ([imagePath hasPrefix:filePrefix]) {
@@ -45,7 +47,7 @@
     CGFloat length = MIN(width, height);
     cropController.toolbarHidden = YES;
     cropController.rotationEnabled = NO;
-    cropController.keepingCropAspectRatio = YES;
+    cropController.keepingCropAspectRatio = self.keepAspectRatio == 0 ? NO : YES;
     
     cropController.imageCropRect = CGRectMake((width - length) / 2,
                                               (height - length) / 2,

--- a/src/ios/CTCrop.m
+++ b/src/ios/CTCrop.m
@@ -4,9 +4,9 @@
 
 @interface CTCrop ()
 @property (copy) NSString* callbackId;
-@property (assign) NSUInteger quality;
-@property (assign) NSUInteger targetWidth;
-@property (assign) NSUInteger targetHeight;
+@property (assign) NSInteger quality;
+@property (assign) NSInteger targetWidth;
+@property (assign) NSInteger targetHeight;
 @property (assign) BOOL keepAspectRatio;
 @end
 
@@ -44,15 +44,11 @@
     
     CGFloat width = self.targetWidth > -1 ? (CGFloat)self.targetWidth : image.size.width;
     CGFloat height = self.targetHeight > -1 ? (CGFloat)self.targetHeight : image.size.height;
-    CGFloat length = MIN(width, height);
     cropController.toolbarHidden = YES;
     cropController.rotationEnabled = NO;
     cropController.keepingCropAspectRatio = self.keepAspectRatio == 0 ? NO : YES;
     
-    cropController.imageCropRect = CGRectMake((width - length) / 2,
-                                              (height - length) / 2,
-                                              length,
-                                              length);
+    cropController.imageCropRect = CGRectMake(0, 0, width, height);
     
     self.callbackId = command.callbackId;
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:cropController];

--- a/src/ios/CTCrop.m
+++ b/src/ios/CTCrop.m
@@ -42,8 +42,22 @@
     cropController.delegate = self;
     cropController.image = image;
     
-    CGFloat width = self.targetWidth > -1 ? (CGFloat)self.targetWidth : image.size.width;
-    CGFloat height = self.targetHeight > -1 ? (CGFloat)self.targetHeight : image.size.height;
+    CGFloat width;
+    CGFloat height;
+    
+    if(self.targetWidth != -1 && self.targetHeight != -1){
+        width = (CGFloat)self.targetWidth;
+        height = (CGFloat)self.targetHeight;
+    } else {
+        if(self.keepAspectRatio != 0){
+            width = MIN(image.size.width, image.size.height);
+            height = width;
+        } else {
+            width = image.size.width;
+            height = image.size.height;
+        }
+    }
+    
     cropController.toolbarHidden = YES;
     cropController.rotationEnabled = NO;
     cropController.keepingCropAspectRatio = self.keepAspectRatio == 0 ? NO : YES;

--- a/www/crop.js
+++ b/www/crop.js
@@ -4,7 +4,7 @@ var crop = module.exports = function cropImage (success, fail, image, options) {
   options.quality = options.quality || 100
   options.targetWidth = options.targetWidth || -1
   options.targetHeight = options.targetHeight || -1
-  options.keepAspectRatio = options.keepAspectRatio || 1
+  options.keepAspectRatio = options.keepAspectRatio || options.keepAspectRatio===0 ? options.keepAspectRatio : 1
   return cordova.exec(success, fail, 'CropPlugin', 'cropImage', [image, options])
 }
 

--- a/www/crop.js
+++ b/www/crop.js
@@ -4,6 +4,7 @@ var crop = module.exports = function cropImage (success, fail, image, options) {
   options.quality = options.quality || 100
   options.targetWidth = options.targetWidth || -1
   options.targetHeight = options.targetHeight || -1
+  options.keepAspectRatio = options.keepAspectRatio || 1
   return cordova.exec(success, fail, 'CropPlugin', 'cropImage', [image, options])
 }
 


### PR DESCRIPTION
This PR adds a new option "keepAspectRatio", to manage the ability to change the cropped image's aspect ratio.

OLD BEHAVIOUR:
-Android : Aspect ratio il locked to 1:1 if targetWidth and targetHeight are equal or if both are -1, else it is not locked;
-iOS : Aspect ratio is always locked to the one specified by targetWidth:targetHeight

NEW BEHAVIOUR:
-Android AND iOS : If keepAspectRatio!=0, aspect ratio is locked to targetWidth:targetHeight (or 1:1 if they are equal). If KeepAspectRatio==0, the ratio is unlocked and can be modified as desired; 

Also, on iOS, it now respects the size specified with targetWidth and targetHeight, instead of starting always with a square cropped image. If -1 is specified on one of the two dimension, that dimension is replaced by the picture corrisponding dimension.

This may be resolving #49, #50, #75 and #76